### PR TITLE
Add initial backend scaffolding and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Database connection string
+DATABASE_URL="postgresql://user:password@localhost:5432/dogstore"
+
+# Stripe API key
+STRIPE_SECRET_KEY="sk_test_yourkey"
+
+# Optional: email provider API key
+EMAIL_API_KEY="your-email-key"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 The DogStore Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# DogStore
+
+This is a demo t‑shirt storefront built with Next.js and Tailwind CSS. It currently renders static products and stores the cart in `localStorage` only. The project serves as a starting point for a real e‑commerce site.
+
+## Getting Started
+
+```bash
+# install dependencies
+pnpm install
+
+# run the development server
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the app.
+
+### Environment Variables
+
+Copy `.env.example` to `.env.local` and fill in the required values.
+
+```bash
+cp .env.example .env.local
+```
+
+## Scripts
+
+- `pnpm dev` – start the development server
+- `pnpm build` – build for production
+- `pnpm start` – run the production build
+
+## License
+
+This project is licensed under the MIT License.

--- a/app/api/cart/[cartId]/route.ts
+++ b/app/api/cart/[cartId]/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Client } from 'pg'
+
+function getClient() {
+  const url = process.env.DATABASE_URL
+  if (!url) throw new Error('DATABASE_URL not set')
+  return new Client({ connectionString: url })
+}
+
+export async function GET(req: NextRequest, { params }: { params: { cartId: string } }) {
+  const client = getClient()
+  await client.connect()
+  const { rows } = await client.query('SELECT * FROM cart_items WHERE cart_id = $1', [params.cartId])
+  await client.end()
+  return NextResponse.json(rows)
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { cartId: string } }) {
+  const body = await req.json()
+  const client = getClient()
+  await client.connect()
+  await client.query('DELETE FROM cart_items WHERE cart_id = $1', [params.cartId])
+  for (const item of body.items ?? []) {
+    await client.query(
+      'INSERT INTO cart_items (cart_id, product_id, quantity, color, size) VALUES ($1, $2, $3, $4, $5)',
+      [params.cartId, item.productId, item.quantity, item.color, item.size]
+    )
+  }
+  await client.end()
+  return NextResponse.json({ ok: true })
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { cartId: string } }) {
+  const client = getClient()
+  await client.connect()
+  await client.query('DELETE FROM cart_items WHERE cart_id = $1', [params.cartId])
+  await client.end()
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server'
+import Stripe from 'stripe'
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', { apiVersion: '2023-10-16' })
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  const session = await stripe.checkout.sessions.create({
+    line_items: body.line_items,
+    mode: 'payment',
+    success_url: body.success_url,
+    cancel_url: body.cancel_url,
+  })
+  return NextResponse.json({ url: session.url })
+}

--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+import Stripe from 'stripe'
+import { Client } from 'pg'
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', { apiVersion: '2023-10-16' })
+
+function getClient() {
+  const url = process.env.DATABASE_URL
+  if (!url) throw new Error('DATABASE_URL not set')
+  return new Client({ connectionString: url })
+}
+
+export async function POST(req: NextRequest) {
+  const payload = await req.text()
+  const sig = req.headers.get('stripe-signature') as string
+  let event: Stripe.Event
+  try {
+    event = stripe.webhooks.constructEvent(payload, sig, process.env.STRIPE_WEBHOOK_SECRET!)
+  } catch (err) {
+    return new NextResponse('Webhook Error', { status: 400 })
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as Stripe.Checkout.Session
+    const client = getClient()
+    await client.connect()
+    await client.query('INSERT INTO orders (cart_id, stripe_session_id, status) VALUES ($1, $2, $3)', [session.client_reference_id, session.id, 'paid'])
+    await client.end()
+  }
+
+  return NextResponse.json({ received: true })
+}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,49 @@
+-- Basic SQL schema for DogStore
+
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE products (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  image TEXT,
+  price INTEGER NOT NULL
+);
+
+CREATE TABLE carts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id INTEGER REFERENCES users(id),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE cart_items (
+  id SERIAL PRIMARY KEY,
+  cart_id UUID REFERENCES carts(id) ON DELETE CASCADE,
+  product_id INTEGER REFERENCES products(id),
+  quantity INTEGER NOT NULL DEFAULT 1,
+  color TEXT,
+  size TEXT
+);
+
+CREATE TABLE orders (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id),
+  cart_id UUID REFERENCES carts(id),
+  stripe_session_id TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE order_items (
+  id SERIAL PRIMARY KEY,
+  order_id INTEGER REFERENCES orders(id) ON DELETE CASCADE,
+  product_id INTEGER REFERENCES products(id),
+  quantity INTEGER NOT NULL,
+  price INTEGER NOT NULL,
+  color TEXT,
+  size TEXT
+);

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,9 @@
+export async function sendOrderConfirmation(to: string, orderId: number) {
+  // TODO: integrate with Resend or Postmark
+  console.log(`send order confirmation to ${to} for order ${orderId}`)
+}
+
+export async function sendShippingUpdate(to: string, trackingUrl: string) {
+  // TODO: integrate with Resend or Postmark
+  console.log(`send shipping update to ${to}: ${trackingUrl}`)
+}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,5 @@
+export function log(...args: any[]) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(...args)
+  }
+}

--- a/lib/ratelimit.ts
+++ b/lib/ratelimit.ts
@@ -1,0 +1,8 @@
+const hits = new Map<string, number>()
+
+export function checkLimit(key: string, limit = 60) {
+  const now = Date.now()
+  const count = hits.get(key) || 0
+  hits.set(key, count + 1)
+  return count < limit
+}

--- a/lib/shipping.ts
+++ b/lib/shipping.ts
@@ -1,0 +1,12 @@
+export async function createLabel(orderId: number) {
+  // TODO: integrate with Shippo or Printful
+  console.log('create shipping label for', orderId)
+}
+
+export function parseTrackingWebhook(payload: any) {
+  // TODO: parse provider webhook
+  return {
+    trackingNumber: payload.tracking_number,
+    status: payload.status,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "seed": "ts-node scripts/seed.ts",
+    "prelaunch": "ts-node scripts/prelaunch.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -57,7 +59,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "pg": "^8.11.3"
   },
   "devDependencies": {
     "@types/node": "^22",
@@ -65,6 +68,7 @@
     "@types/react-dom": "^19",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "ts-node": "^10.9.1"
   }
 }

--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -1,0 +1,3 @@
+# Privacy Policy
+
+TODO: Add your store's privacy policy here.

--- a/pages/refund.md
+++ b/pages/refund.md
@@ -1,0 +1,3 @@
+# Refund Policy
+
+TODO: Describe your refund policy here.

--- a/pages/terms.md
+++ b/pages/terms.md
@@ -1,0 +1,3 @@
+# Terms and Conditions
+
+TODO: Add your terms of service here.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+  </url>
+</urlset>

--- a/scripts/prelaunch.ts
+++ b/scripts/prelaunch.ts
@@ -1,0 +1,21 @@
+import fs from 'fs'
+
+const required = ['DATABASE_URL', 'STRIPE_SECRET_KEY']
+let ok = true
+for (const key of required) {
+  if (!process.env[key]) {
+    console.error(`Missing env var ${key}`)
+    ok = false
+  }
+}
+
+if (!fs.existsSync('db/schema.sql')) {
+  console.error('Missing db/schema.sql')
+  ok = false
+}
+
+if (!ok) {
+  process.exit(1)
+} else {
+  console.log('Prelaunch check passed')
+}

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,30 @@
+import { Client } from 'pg'
+import * as fs from 'fs'
+import * as path from 'path'
+
+async function main() {
+  const dbUrl = process.env.DATABASE_URL
+  if (!dbUrl) {
+    console.error('DATABASE_URL is not set')
+    process.exit(1)
+  }
+
+  const client = new Client({ connectionString: dbUrl })
+  await client.connect()
+
+  const file = path.join(__dirname, '../db/schema.sql')
+  const sql = fs.readFileSync(file, 'utf8')
+  await client.query(sql)
+
+  await client.query(`INSERT INTO products (name, description, image, price) VALUES
+    ('Puppy Tee', 'Cute puppy print', '/placeholder.jpg', 2500),
+    ('Doggo Hoodie', 'Warm and comfy', '/placeholder.jpg', 4500)
+  `)
+
+  await client.end()
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add README with setup instructions
- create `.env.example` template
- add MIT license
- add SQL schema and seed script for products
- scaffold cart, checkout, and webhook API routes
- add email, shipping, logger, and rate-limit utilities
- add basic legal pages and SEO meta files
- include a prelaunch check script

## Testing
- `pnpm lint` *(fails: `next` not found)*